### PR TITLE
Set versions of build & runtime dependencies via shell expansion in rpm spec

### DIFF
--- a/buildrpm/rook.spec
+++ b/buildrpm/rook.spec
@@ -6,26 +6,12 @@
 %global app_version {{{$version}}}
 %global oracle_release_version 1
 
-%global yqv3_version 3.3.0
-{{{- if semverCompare ">=1.15.9" $version }}}
-%global yqv4_version 4.45.1
-%global controllergen_version 0.16.1
-{{{- else }}}
-%global yqv4_version 4.14.2
-%global controllergen_version 0.11.3
-{{{- end }}}
-{{{- if semverCompare ">=1.13.10" $version }}}
-%global operatorsdk_version 1.27.0
-{{{- else }}}
-%global operatorsdk_version 0.17.1
-{{{- end }}}
-{{{- if semverCompare ">=1.17.7" $version }}}
-%global helm_version 3.18.4
-{{{- else if semverCompare ">=1.16.6" $version }}}
-%global helm_version 3.17.3
-{{{- else }}}
-%global helm_version 3.6.2
-{{{- end }}}
+%global yqv3_version %(echo $(grep ^YQv3_VERSION images/ceph/Makefile | cut -d= -f2) | awk '{$1=$1;print}')
+%global yqv4_version %(echo $(grep ^YQ_VERSION build/makelib/golang.mk | cut -d= -f2 | cut -dv -f2) | awk '{$1=$1;print}')
+%global controllergen_version %(echo $(grep ^CONTROLLER_GEN_VERSION Makefile | cut -d= -f2 | cut -dv -f2) | awk '{$1=$1;print}')
+%global operatorsdk_version %(echo $(grep ^OPERATOR_SDK_VERSION images/ceph/Makefile | cut -d= -f2 | cut -dv -f2) | awk '{$1=$1;print}')
+%global helm_version %(echo $(grep ^HELM_VERSION build/makelib/helm.mk | cut -d= -f2 | cut -dv -f2) | awk '{$1=$1;print}')
+%global s5cmd_version %(echo $(grep ^S5CMD_VERSION images/ceph/Makefile | cut -d= -f2) | awk '{$1=$1;print}')
 %global kubectl_version 1.14
 %ifarch %{arm} arm64 aarch64
 %global arch arm64
@@ -50,7 +36,7 @@ Patch1:  images_ceph_set-ceph-debug-level.patch
 Patch2:  disable-topology.patch
 {{{- end }}}
 
-Requires:       s5cmd
+Requires:       s5cmd = %{s5cmd_version}
 
 BuildRequires:  golang
 BuildRequires:  helm = %{helm_version}


### PR DESCRIPTION
Set versions of build & runtime dependencies via shell expansion in rpm spec. This will prevent/minimize manual modifications for adjusting versions of build and runtime dependencies.